### PR TITLE
Enable configuration of YouTube Player parameters (#1301)

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -529,6 +529,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.hamcrest</artifactId>
+            <version>1.0.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.adobe.aem</groupId>
             <artifactId>uber-jar</artifactId>
             <classifier>apis</classifier>

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/embeddable/YouTubeImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/embeddable/YouTubeImpl.java
@@ -1,0 +1,224 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v1.embeddable;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceWrapper;
+import org.apache.sling.models.annotations.DefaultInjectionStrategy;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
+import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
+import org.apache.sling.models.annotations.injectorspecific.Self;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.cq.wcm.core.components.models.embeddable.YouTube;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.components.ComponentContext;
+import com.day.cq.wcm.api.designer.Style;
+import com.day.cq.wcm.api.policies.ContentPolicy;
+import com.day.cq.wcm.api.policies.ContentPolicyManager;
+import com.day.cq.wcm.commons.policy.ContentPolicyStyle;
+
+@Model(
+        adaptables = SlingHttpServletRequest.class,
+        adapters = { YouTube.class },
+        defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
+    )
+public class YouTubeImpl implements YouTube {
+
+    /**
+     * URL pattern is defined in https://developers.google.com/youtube/player_parameters
+     */
+    private static final String BASE_EMBED_URL = "https://www.youtube.com/embed/%s";
+    private static final String PARAMETER_ORIGIN = "origin";
+    private static final String PARAMETER_MUTE = "mute"; // not documented but still works
+    private static final String PARAMETER_LOOP = "loop";
+    private static final String PARAMETER_AUTOPLAY = "autoplay";
+    private static final String PARAMETER_REL = "rel";
+    private static final String PARAMETER_PLAYS_INLINE = "playsinline";
+    private static final String PARAMETER_PLAYLIST = "playlist";
+    private static final String PARAMETER_LANGUAGE = "hl";
+
+    /**
+     * Standard logger.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(YouTubeImpl.class);
+
+    @ValueMapValue(name = PN_VIDEO_ID)
+    @Nullable
+    private String videoId;
+
+    @ValueMapValue(name = PN_WIDTH)
+    @Nullable
+    private String iFrameWidth;
+
+    @ValueMapValue(name = PN_HEIGHT)
+    @Nullable
+    private String iFrameHeight;
+
+    @ValueMapValue(name = PN_MUTE)
+    @Nullable
+    private Boolean isMute;
+
+    @ValueMapValue(name = PN_AUTOPLAY)
+    @Nullable
+    private Boolean isAutoPlay;
+
+    @ValueMapValue(name = PN_LOOP)
+    @Nullable
+    private Boolean isLoop;
+
+    @ValueMapValue(name = PN_REL)
+    @Nullable
+    private Boolean isRel;
+    
+    @ValueMapValue(name = PN_PLAYS_INLINE)
+    @Nullable
+    private Boolean isPlaysInline;
+
+    @ScriptVariable(injectionStrategy = InjectionStrategy.REQUIRED)
+    private Page currentPage;
+
+    @ScriptVariable(injectionStrategy = InjectionStrategy.REQUIRED)
+    private ComponentContext componentContext;
+
+    @Self
+    private SlingHttpServletRequest request;
+
+    @Override
+    public boolean isEmpty() {
+        return StringUtils.isBlank(videoId);
+    }
+
+    @Override
+    public @Nullable String getIFrameWidth() {
+        return iFrameWidth;
+    }
+
+    @Override
+    public @Nullable String getIFrameHeight() {
+        return iFrameHeight;
+    }
+
+    private static @Nullable Resource getWrappedResource(Resource resource) {
+        if (resource instanceof ResourceWrapper) {
+            return ResourceWrapper.class.cast(resource).getResource();
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Relying on the injected currentStyle does not work, as this uses the wrong resource type "youtube" instead of "embed".
+     * This helper method rebuilds the logic from "com.day.cq.wcm.scripting.impl.WcmBindingsValesProvider" but uses the wrapped resource.
+     * @return the style for the  wrapped resource
+     */
+     Style getStyleForWrappedResource(Resource resource) {
+        ContentPolicyManager policyManager = resource.getResourceResolver().adaptTo(ContentPolicyManager.class);
+        if (policyManager != null) {
+            Resource wrappedResource = getWrappedResource(resource);
+            if (wrappedResource != null) {
+                ContentPolicy currentPolicy = policyManager.getPolicy(wrappedResource, request);
+                if (currentPolicy != null) {
+                    return new ContentPolicyStyle(currentPolicy, componentContext.getCell());
+                } else {
+                    LOGGER.debug("No policy found for wrapped resource {}", wrappedResource);
+                }
+            } else {
+                LOGGER.debug("The current resource is not a wrapped resource: {}", resource);
+            }
+        } else {
+            LOGGER.debug("Could not get ContentPolicyManager from resource resolver. Probably service not running!");
+        }
+        return null;
+    }
+
+    @Override
+    public @Nullable String getIFrameSrc() throws URISyntaxException {
+        Optional<URI> uri = getIFrameSrc(getStyleForWrappedResource(request.getResource()));
+        if (!uri.isPresent()) {
+            return null;
+        } else {
+            return uri.get().toString();
+        }
+    }
+   
+    Optional<URI> getIFrameSrc(Style currentStyle) throws URISyntaxException {
+        if (isEmpty()) {
+            return Optional.empty();
+        }
+        URIBuilder uriBuilder = new URIBuilder(String.format(BASE_EMBED_URL, videoId));
+        StringBuffer requestURL = request.getRequestURL();
+        String currentProtocolHostandPort = requestURL.substring(0, requestURL.length() - request.getPathInfo().length());
+        uriBuilder.addParameter(PARAMETER_ORIGIN, currentProtocolHostandPort);
+        uriBuilder.addParameter(PARAMETER_LANGUAGE, currentPage.getLanguage().toString());
+        // optional parameters
+        if (currentStyle != null) {
+            if (Boolean.TRUE.equals(currentStyle.get(PN_DESIGN_MUTE_ENABLED, false))) {
+                addYouTubeBooleanUriParameter(uriBuilder, PARAMETER_MUTE, isMute, currentStyle, PN_DESIGN_MUTE_DEFAULT_VALUE);
+            }
+            if (Boolean.TRUE.equals(currentStyle.get(PN_DESIGN_AUTOPLAY_ENABLED, false))) {
+                // going via WCMMode to determine if one is on publish does not work as this resource is included explicitly with wcmmode=disabled
+                // therefore use edit context of parent component
+                if (componentContext.getParent().getEditContext() == null) {
+                    addYouTubeBooleanUriParameter(uriBuilder, PARAMETER_AUTOPLAY, isAutoPlay, currentStyle, PN_DESIGN_AUTOPLAY_DEFAULT_VALUE);
+                } else {
+                    LOGGER.debug("Autoplay disabled because WCMMode is not disabled");
+                }
+            }
+            if (Boolean.TRUE.equals(currentStyle.get(PN_DESIGN_LOOP_ENABLED, false))) {
+                if (addYouTubeBooleanUriParameter(uriBuilder, PARAMETER_LOOP, isLoop, currentStyle, PN_DESIGN_LOOP_DEFAULT_VALUE)) {
+                    // from https://developers.google.com/youtube/player_parameters#loop
+                    // This parameter has limited support in IFrame embeds. To loop a single video, set the loop parameter value to 1 and set the playlist parameter value to the same video ID already specified in the Player API URL
+                    uriBuilder.addParameter(PARAMETER_PLAYLIST, videoId);
+                }
+            }
+            if (Boolean.TRUE.equals(currentStyle.get(PN_DESIGN_RELATED_VIDEOS_ENABLED, false))) {
+                addYouTubeBooleanUriParameter(uriBuilder, PARAMETER_REL, isRel, currentStyle, PN_DESIGN_RELATED_VIDEOS_DEFAULT_VALUE);
+            }
+            if (Boolean.TRUE.equals(currentStyle.get(PN_DESIGN_PLAYS_INLINE_ENABLED, false))) {
+                addYouTubeBooleanUriParameter(uriBuilder, PARAMETER_PLAYS_INLINE, isPlaysInline, currentStyle, PN_DESIGN_PLAYS_INLINE_DEFAULT_VALUE);
+            }
+        } else {
+            LOGGER.debug("No style available, optional YouTube parameters are not used!");
+        }
+        return Optional.of(uriBuilder.build());
+    }
+
+    boolean getBooleanValueOrDefaultFromStyle(Boolean value, Style style, String stylePropertyName) {
+        if (value == null) {
+            return style.get(stylePropertyName, false);
+        } else {
+            return value.booleanValue();
+        }
+    }
+
+    boolean addYouTubeBooleanUriParameter(URIBuilder uriBuilder, String parameterName, Boolean value, Style style, String stylePropertyName) {
+        boolean effectiveValue = getBooleanValueOrDefaultFromStyle(value, style, stylePropertyName);
+        uriBuilder.addParameter(parameterName, effectiveValue ? "1" : "0");
+        return effectiveValue;
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/embed/EmbedDesignTabsDataSourceServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/embed/EmbedDesignTabsDataSourceServlet.java
@@ -1,0 +1,82 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.servlets.embed;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.Servlet;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.jetbrains.annotations.NotNull;
+import org.osgi.service.component.annotations.Component;
+
+import com.adobe.cq.wcm.core.components.internal.servlets.embed.EmbeddablesDataSourceServlet.EmbeddableDescription;
+import com.adobe.granite.ui.components.ds.DataSource;
+import com.adobe.granite.ui.components.ds.SimpleDataSource;
+
+/**
+ * Data source that returns the design dialog options for all allowed embeddables,
+ * optionally preceded and/or succeeded by some other static tabs. 
+ */
+@Component(
+    service = { Servlet.class },
+    property = {
+        "sling.servlet.resourceTypes=" + EmbedDesignTabsDataSourceServlet.RESOURCE_TYPE_V1,
+        "sling.servlet.methods=GET",
+        "sling.servlet.extensions=html"
+    }
+)
+public class EmbedDesignTabsDataSourceServlet extends SlingSafeMethodsServlet {
+
+    public static final String RESOURCE_TYPE_V1 = "core/wcm/components/embed/v1/datasources/embeddesigntabs";
+
+    private static final long serialVersionUID = 7672484310019288602L;
+    private static final String NN_DESIGN_DIALOG = "cq:design_dialog";
+
+    @Override
+    protected void doGet(@NotNull SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response) {
+        SimpleDataSource embeddableOptionsDataSource = new SimpleDataSource(getEmbedDesignTabs(request).iterator());
+        request.setAttribute(DataSource.class.getName(), embeddableOptionsDataSource);
+    }
+
+    private List<Resource> getEmbedDesignTabs(@NotNull SlingHttpServletRequest request) {
+        List<Resource> embedDesignTabs = new ArrayList<>();
+        // first include static tabs below "firsttabs"
+        Resource firstTabs = request.getResource().getChild("firsttabs");
+        if (firstTabs != null) {
+            firstTabs.getChildren().forEach(embedDesignTabs::add);
+        }
+        ResourceResolver resolver = request.getResourceResolver();
+        // then dynamic tabs for embeddables
+        for (EmbeddableDescription embeddableDescription : EmbeddablesDataSourceServlet.findEmbeddables(request.getResourceResolver())) {
+            Resource embeddableDesignTab = resolver.getResource(embeddableDescription.getResourceType() + "/" + NN_DESIGN_DIALOG);
+            if (embeddableDesignTab != null) {
+                embedDesignTabs.add(embeddableDesignTab);
+            }
+        }
+        // last include static tabs below "lasttabs"
+        Resource lastTabs = request.getResource().getChild("lasttabs");
+        if (lastTabs != null) {
+            lastTabs.getChildren().forEach(embedDesignTabs::add);
+        }
+        return embedDesignTabs;
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/embed/EmbeddablesDataSourceServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/servlets/embed/EmbeddablesDataSourceServlet.java
@@ -80,7 +80,7 @@ public class EmbeddablesDataSourceServlet extends SlingSafeMethodsServlet {
         return embeddableResources;
     }
 
-    private Collection<EmbeddableDescription> findEmbeddables(ResourceResolver resourceResolver) {
+    static Collection<EmbeddableDescription> findEmbeddables(ResourceResolver resourceResolver) {
         String[] searchPaths = resourceResolver.getSearchPath();
         for (int i = 0; i < searchPaths.length; i++) {
             searchPaths[i] = searchPaths[i].substring(0, searchPaths[i].length() - 1);

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/embeddable/YouTube.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/embeddable/YouTube.java
@@ -1,0 +1,85 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.models.embeddable;
+
+import java.net.URISyntaxException;
+
+import org.jetbrains.annotations.Nullable;
+
+public interface YouTube {
+
+    /**
+     * Name of the resource property that defines the id of the YouTube video.
+     */
+    String PN_VIDEO_ID = "youtubeVideoId";
+
+    /**
+     * Name of the resource property that defines the width of the iFrame hosting the YouTube video.
+     */
+    String PN_WIDTH = "youtubeWidth";
+
+    /**
+     * Name of the resource property that defines the height of the iFrame hosting the YouTube video.
+     */
+    String PN_HEIGHT = "youtubeHeight";
+
+    /* The following resource property names are used for optional YouTube player paramters */
+    String PN_AUTOPLAY = "youtubeAutoPlay";
+    
+    String PN_MUTE = "youtubeMute";
+
+    String PN_LOOP = "youtubeLoop";
+
+    String PN_REL = "youtubeRel";
+
+    String PN_PLAYS_INLINE = "youtubePlaysInline";
+
+    String PN_DESIGN_MUTE_ENABLED = "youtubeMuteEnabled";
+
+    String PN_DESIGN_MUTE_DEFAULT_VALUE = "youtubeMuteDefaultValue";
+    
+    String PN_DESIGN_AUTOPLAY_ENABLED = "youtubeAutoPlayEnabled";
+
+    String PN_DESIGN_AUTOPLAY_DEFAULT_VALUE = "youtubeAutoPlayDefaultValue";
+
+    String PN_DESIGN_LOOP_ENABLED = "youtubeLoopEnabled";
+
+    String PN_DESIGN_LOOP_DEFAULT_VALUE = "youtubeLoopDefaultValue";
+
+    String PN_DESIGN_RELATED_VIDEOS_ENABLED = "youtubeRelatedVideosEnabled";
+
+    String PN_DESIGN_RELATED_VIDEOS_DEFAULT_VALUE = "youtubeRelatedVideosDefaultValue";
+
+    String PN_DESIGN_PLAYS_INLINE_ENABLED = "youtubePlaysInlineEnabled";
+
+    String  PN_DESIGN_PLAYS_INLINE_DEFAULT_VALUE = "youtubePlaysInlineDefaultValue";
+
+    default @Nullable String getIFrameWidth() {
+        throw new UnsupportedOperationException();
+    }
+
+    default @Nullable String getIFrameHeight() {
+        throw new UnsupportedOperationException();
+    }
+
+    default @Nullable String getIFrameSrc() throws URISyntaxException {
+        throw new UnsupportedOperationException();
+    }
+
+    default boolean isEmpty() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/embeddable/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/embeddable/package-info.java
@@ -1,0 +1,19 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+@Version("1.0.0")
+package com.adobe.cq.wcm.core.components.models.embeddable;
+
+import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/embeddable/YouTubeImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/embeddable/YouTubeImplTest.java
@@ -1,0 +1,199 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.models.v1.embeddable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.Locale;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceWrapper;
+import org.apache.sling.api.scripting.SlingBindings;
+import org.apache.sling.models.factory.ModelFactory;
+import org.apache.sling.servlethelpers.MockRequestPathInfo;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
+import com.adobe.cq.wcm.core.components.models.embeddable.YouTube;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.components.ComponentContext;
+import com.day.cq.wcm.api.components.EditContext;
+import com.day.cq.wcm.api.designer.Style;
+import com.day.cq.wcm.scripting.WCMBindingsConstants;
+
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(AemContextExtension.class)
+class YouTubeImplTest {
+
+    private static final String BASE = "/embed/embeddable/youtube";
+    private static final String CONTENT_ROOT = "/content";
+    private static final String ROOT_PAGE = "/content/youtube";
+    private static final String GRID = ROOT_PAGE + "/jcr:content/root/responsivegrid";
+    private static final String VIDEO_1 = "/video1";
+    private static final String VIDEO_2 = "/video2";
+    private static final String VIDEO_3 = "/video3";
+    private static final String PATH_VIDEO_1 = GRID + VIDEO_1;
+    private static final String PATH_VIDEO_2 = GRID + VIDEO_2;
+    private static final String PATH_VIDEO_3 = GRID + VIDEO_3;
+
+    private final AemContext context = CoreComponentTestContext.newAemContext();
+
+    @Mock
+    private Style style;
+
+    @Mock
+    private Page page;
+
+    @Mock
+    private ComponentContext componentContext;
+    
+    @Mock
+    private ComponentContext parentComponentContext;
+
+    @Mock
+    private EditContext editContext;
+
+    @BeforeEach
+    void setUp() {
+        context.load().json(BASE + CoreComponentTestContext.TEST_CONTENT_JSON, CONTENT_ROOT);
+        style = mock(Style.class);
+        // by default all parameters configurable and by enabled
+        Mockito.lenient().when(style.get(YouTube.PN_DESIGN_AUTOPLAY_ENABLED, false)).thenReturn(true);
+        Mockito.lenient().when(style.get(YouTube.PN_DESIGN_AUTOPLAY_DEFAULT_VALUE, false)).thenReturn(true);
+        Mockito.lenient().when(style.get(YouTube.PN_DESIGN_MUTE_ENABLED, false)).thenReturn(true);
+        Mockito.lenient().when(style.get(YouTube.PN_DESIGN_MUTE_DEFAULT_VALUE, false)).thenReturn(true);
+        Mockito.lenient().when(style.get(YouTube.PN_DESIGN_LOOP_ENABLED, false)).thenReturn(true);
+        Mockito.lenient().when(style.get(YouTube.PN_DESIGN_LOOP_DEFAULT_VALUE, false)).thenReturn(true);
+        Mockito.lenient().when(style.get(YouTube.PN_DESIGN_RELATED_VIDEOS_ENABLED, false)).thenReturn(true);
+        Mockito.lenient().when(style.get(YouTube.PN_DESIGN_RELATED_VIDEOS_DEFAULT_VALUE, false)).thenReturn(true);
+        Mockito.lenient().when(style.get(YouTube.PN_DESIGN_PLAYS_INLINE_ENABLED, false)).thenReturn(true);
+        Mockito.lenient().when(style.get(YouTube.PN_DESIGN_PLAYS_INLINE_DEFAULT_VALUE, false)).thenReturn(true);
+        Mockito.lenient().when(componentContext.getParent()).thenReturn(parentComponentContext);
+    }
+
+    @Test
+    void testWithDefaultValues() throws URISyntaxException {
+        Mockito.when(page.getLanguage()).thenReturn(Locale.US);
+        YouTubeImpl youTube = getYouTubeUnderTest(PATH_VIDEO_1);
+        assertEquals(new URI("https://www.youtube.com/embed/2R2gb0MKJlo?origin=http%3A%2F%2Flocalhost&hl=en_US&mute=1&autoplay=1&loop=1&playlist=2R2gb0MKJlo&rel=1&playsinline=1"), youTube.getIFrameSrc(style).get());
+        assertEquals("300", youTube.getIFrameWidth());
+        assertEquals("200", youTube.getIFrameHeight());
+    }
+
+    @Test
+    void testWithDefaultValuesInEditMode() throws URISyntaxException {
+        Mockito.when(page.getLanguage()).thenReturn(Locale.US);
+        Mockito.when(parentComponentContext.getEditContext()).thenReturn(editContext);
+        YouTubeImpl youTube = getYouTubeUnderTest(PATH_VIDEO_1);
+        // autoplay should not be set in edit mode
+        assertEquals(new URI("https://www.youtube.com/embed/2R2gb0MKJlo?origin=http%3A%2F%2Flocalhost&hl=en_US&mute=1&loop=1&playlist=2R2gb0MKJlo&rel=1&playsinline=1"), youTube.getIFrameSrc(style).get());
+        assertEquals("300", youTube.getIFrameWidth());
+        assertEquals("200", youTube.getIFrameHeight());
+    }
+
+    @Test
+    void testWithOverriddenValues() throws URISyntaxException {
+        Mockito.when(page.getLanguage()).thenReturn(Locale.GERMANY);
+        YouTubeImpl youTube = getYouTubeUnderTest(PATH_VIDEO_2);
+        assertEquals(new URI("https://www.youtube.com/embed/2R2gb0MKJlo?origin=http%3A%2F%2Flocalhost&hl=de_DE&mute=0&autoplay=0&loop=0&rel=0&playsinline=0"), youTube.getIFrameSrc(style).get());
+        assertNull(youTube.getIFrameWidth());
+        assertNull(youTube.getIFrameHeight());
+    }
+
+    @Test
+    void testWithOverriddenValuesWithoutStyle() throws URISyntaxException {
+        Mockito.when(page.getLanguage()).thenReturn(Locale.GERMANY);
+        YouTubeImpl youTube = getYouTubeUnderTest(PATH_VIDEO_2);
+        assertEquals("https://www.youtube.com/embed/2R2gb0MKJlo?origin=http%3A%2F%2Flocalhost&hl=de_DE", youTube.getIFrameSrc());
+        assertNull(youTube.getIFrameWidth());
+        assertNull(youTube.getIFrameHeight());
+    }
+
+    @Test
+    void testWithAllOptionalFeaturesDisabled() throws URISyntaxException {
+        Mockito.when(page.getLanguage()).thenReturn(Locale.US);
+        Mockito.when(style.get(YouTube.PN_DESIGN_AUTOPLAY_ENABLED, false)).thenReturn(false);
+        Mockito.when(style.get(YouTube.PN_DESIGN_MUTE_ENABLED, false)).thenReturn(false);
+        Mockito.when(style.get(YouTube.PN_DESIGN_LOOP_ENABLED, false)).thenReturn(false);
+        Mockito.when(style.get(YouTube.PN_DESIGN_RELATED_VIDEOS_ENABLED, false)).thenReturn(false);
+        Mockito.when(style.get(YouTube.PN_DESIGN_PLAYS_INLINE_ENABLED, false)).thenReturn(false);
+        YouTubeImpl youTube = getYouTubeUnderTest(PATH_VIDEO_2);
+        assertEquals(new URI("https://www.youtube.com/embed/2R2gb0MKJlo?origin=http%3A%2F%2Flocalhost&hl=en_US"), youTube.getIFrameSrc(style).get());
+        assertNull(youTube.getIFrameWidth());
+        assertNull(youTube.getIFrameHeight());
+    }
+
+    @Test
+    void testWithNoId() throws URISyntaxException {
+        YouTubeImpl youTube = getYouTubeUnderTest(PATH_VIDEO_3);
+        assertFalse(youTube.getIFrameSrc(style).isPresent());
+        assertNull(youTube.getIFrameWidth());
+        assertNull(youTube.getIFrameHeight());
+    }
+
+    private YouTubeImpl getYouTubeUnderTest(String resourcePath) {
+        Resource resource = context.resourceResolver().getResource(resourcePath);
+        if (resource == null) {
+            throw new IllegalStateException("Did you forget to define test resource " + resourcePath + "?");
+        }
+        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(context.resourceResolver(),
+            context.bundleContext());
+        SlingBindings bindings = new SlingBindings();
+        bindings.put(SlingBindings.RESOURCE, resource);
+        bindings.put(SlingBindings.REQUEST, request);
+        bindings.put(WCMBindingsConstants.NAME_CURRENT_PAGE, page);
+        bindings.put(WCMBindingsConstants.NAME_COMPONENT_CONTEXT, componentContext);
+        bindings.put(WCMBindingsConstants.NAME_PROPERTIES, resource.getValueMap());
+        ((MockRequestPathInfo)request.getRequestPathInfo()).setResourcePath(resourcePath);
+        request.setResource(resource);
+        request.setAttribute(SlingBindings.class.getName(), bindings);
+        ModelFactory modelFactory = context.getService(ModelFactory.class);
+        YouTubeImpl youTubeImpl = (YouTubeImpl)modelFactory.createModel(request, YouTube.class);
+        return youTubeImpl;
+    }
+
+    @Test
+    public void testGetStyleForWrappedResource() {
+        YouTubeImpl youTube = getYouTubeUnderTest(PATH_VIDEO_3);
+        Resource resource = context.resourceResolver().getResource(PATH_VIDEO_3);
+        if (resource == null) {
+            throw new IllegalStateException("Did you forget to define test resource " + PATH_VIDEO_3 + "?");
+        }
+        context.contentPolicyMapping(resource.getResourceType(), Collections.singletonMap("test", "foo"));
+        Style style = youTube.getStyleForWrappedResource(new ResourceWrapper(resource) {
+            @Override
+            public String getResourceType() {
+                return "overriddenResourceType";
+            }
+        });
+        assertEquals("foo", style.get("test", "bar"));
+    }
+}

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/embed/EmbedDesignTabsDataSourceServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/servlets/embed/EmbedDesignTabsDataSourceServletTest.java
@@ -1,0 +1,123 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.wcm.core.components.internal.servlets.embed;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.hamcrest.ResourceMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
+import com.adobe.cq.wcm.core.components.internal.servlets.embed.EmbeddablesDataSourceServlet.EmbeddableDataResourceSource;
+import com.adobe.cq.wcm.core.components.internal.servlets.embed.EmbeddablesDataSourceServlet.EmbeddableDescription;
+import com.adobe.granite.ui.components.ds.DataSource;
+import com.adobe.granite.ui.components.ds.SimpleDataSource;
+
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+
+@ExtendWith(AemContextExtension.class)
+public class EmbedDesignTabsDataSourceServletTest {
+
+    private static final String TEST_BASE = "/embed/v1/datasources/embeddesigntabs";
+    private static final String APPS_ROOT = "/apps";
+
+    public final AemContext context = CoreComponentTestContext.newAemContext();
+
+    private SlingHttpServletRequest request;
+
+    List<Resource> embeddableResources = new ArrayList<>();
+
+    @BeforeEach
+    public void setUp() {
+        context.load().json(TEST_BASE + CoreComponentTestContext.TEST_CONTENT_JSON, APPS_ROOT);
+
+        Resource embeddable1 = Objects.requireNonNull(context.resourceResolver().getResource("/apps/my-app/youtube"));
+        Resource embeddable2 = Objects.requireNonNull(context.resourceResolver().getResource("/apps/my-app/chatbot"));
+        Resource embeddable3 = Objects.requireNonNull(context.resourceResolver().getResource("/apps/my-app/social"));
+        embeddableResources.add(embeddable1);
+        embeddableResources.add(embeddable2);
+        embeddableResources.add(embeddable3);
+        
+        context.currentResource("/apps/embed");
+        request = Mockito.spy(context.request());
+        ResourceResolver resolver = Mockito.spy(context.resourceResolver());
+        when(request.getResourceResolver()).thenReturn(resolver);
+        final String rt = embeddable1.getPath().substring("/apps".length() + 1);
+
+        List<Resource> outputResources = new ArrayList<>();
+        outputResources.add(new EmbeddableDataResourceSource(
+            new EmbeddableDescription(rt, embeddable1.getName(), embeddable1.getValueMap()), resolver));
+        outputResources.add(new EmbeddableDataResourceSource(
+            new EmbeddableDescription(rt, embeddable2.getName(), embeddable2.getValueMap()), resolver));
+        context.request().setAttribute(DataSource.class.getName(), new SimpleDataSource(outputResources.iterator()));
+
+        when(resolver.findResources(any(), any())).thenReturn(embeddableResources.iterator());
+        when(resolver.getSearchPath()).thenReturn(context.resourceResolver().getSearchPath());
+    }
+
+    @Test
+    public void testEmbedDesignTabsDataSourceServlet() {
+        EmbedDesignTabsDataSourceServlet dataSourceServlet = new EmbedDesignTabsDataSourceServlet();
+        dataSourceServlet.doGet(request, context.response());
+        DataSource dataSource = (com.adobe.granite.ui.components.ds.DataSource) request.getAttribute(DataSource.class
+            .getName());
+        assertNotNull(dataSource);
+        Iterator<Resource> resourceIterator = dataSource.iterator();
+        Resource resourceTab = resourceIterator.next();
+        assertNotNull(resourceTab);
+        
+        Object[] expectedProperties = new Object[] {
+                "jcr:primaryType", "nt:unstructured"
+        };
+        MatcherAssert.assertThat(resourceTab, ResourceMatchers.nameAndProps("first", expectedProperties));
+        
+        resourceTab = resourceIterator.next();
+        assertNotNull(resourceTab);
+        MatcherAssert.assertThat(resourceTab, ResourceMatchers.nameAndProps("second", expectedProperties));
+        
+        Object[] expectedProperties2 = new Object[] {
+                "jcr:primaryType", "nt:unstructured",
+                "jcr:title", "YouTube Design Tab",
+                "sling:resourceType", "granite/ui/components/coral/foundation/container"
+        };
+        resourceTab = resourceIterator.next();
+        assertNotNull(resourceTab);
+        MatcherAssert.assertThat(resourceTab, ResourceMatchers.nameAndProps("cq:design_dialog", expectedProperties2));
+        
+        resourceTab = resourceIterator.next();
+        assertNotNull(resourceTab);
+        MatcherAssert.assertThat(resourceTab, ResourceMatchers.nameAndProps("last", expectedProperties));
+        
+        assertFalse(resourceIterator.hasNext());
+        
+    }
+}

--- a/bundles/core/src/test/resources/embed/embeddable/youtube/test-content.json
+++ b/bundles/core/src/test/resources/embed/embeddable/youtube/test-content.json
@@ -1,0 +1,46 @@
+{
+    "youtube": {
+        "jcr:primaryType": "cq:Page",
+        "jcr:content": {
+            "jcr:primaryType": "cq:PageContent",
+            "jcr:title": "Embed Test Page",
+            "sling:resourceType": "core/wcm/components/page/v2/page",
+            "jcr:description": "Test page with embed component configurations",
+            "root": {
+                "jcr:primaryType": "nt:unstructured",
+                "sling:resourceType": "wcm/foundation/components/responsivegrid",
+                "responsivegrid": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "sling:resourceType": "wcm/foundation/components/responsivegrid",
+                    "video1": {
+                        "jcr:primaryType": "nt:unstructured",
+                        "sling:resourceType": "core/wcm/components/embed/v1/embed",
+                        "type": "embeddable",
+                        "embeddableResourceType": "core/wcm/components/embed/v1/embed/embeddable/youtube",
+                        "youtubeVideoId": "2R2gb0MKJlo",
+                        "youtubeWidth": "300",
+                        "youtubeHeight": "200"
+                    },
+                    "video2": {
+                        "jcr:primaryType": "nt:unstructured",
+                        "sling:resourceType": "core/wcm/components/embed/v1/embed",
+                        "type": "embeddable",
+                        "embeddableResourceType": "core/wcm/components/embed/v1/embed/embeddable/youtube",
+                        "youtubeVideoId": "2R2gb0MKJlo",
+                        "youtubeAutoPlay": "false",
+                        "youtubeMute": "false",
+                        "youtubeLoop": "false",
+                        "youtubeRel": "false",
+                        "youtubePlaysInline": "false"
+                    },
+                    "video3": {
+                        "jcr:primaryType": "nt:unstructured",
+                        "sling:resourceType": "core/wcm/components/embed/v1/embed",
+                        "type": "embeddable",
+                        "embeddableResourceType": "core/wcm/components/embed/v1/embed/embeddable/youtube"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bundles/core/src/test/resources/embed/v1/datasources/embeddesigntabs/test-content.json
+++ b/bundles/core/src/test/resources/embed/v1/datasources/embeddesigntabs/test-content.json
@@ -1,0 +1,203 @@
+{
+    "jcr:primaryType": "nt:unstructured",
+    "embed": {
+        "jcr:primaryType": "nt:unstructured",
+        "embeddesigntabsdatasource": {
+            "jcr:primaryType": "nt:unstructured",
+            "sling:resourceType": "core/wcm/components/embed/v1/datasources/embeddesigntabs" 
+        },
+        "firsttabs": {
+            "jcr:primaryType": "nt:unstructured",
+            "first" : {
+                "jcr:primaryType": "nt:unstructured"
+            },
+            "second": {
+                "jcr:primaryType": "nt:unstructured"
+            }
+        },
+        "lasttabs": {
+            "jcr:primaryType": "nt:unstructured",
+             "last": {
+                "jcr:primaryType": "nt:unstructured"
+            }
+        }
+    },
+   
+    "my-app": {
+        "youtube": {
+            "jcr:primaryType": "cq:Component",
+            "jcr:title": "YouTube",
+            "sling:resourceSuperType": "core/wcm/components/embed/v1/embed/embeddable",
+            "order": 1,
+            "componentGroup": ".hidden",
+            "youtube.html": {
+                "jcr:primaryType": "nt:file",
+                "jcr:createdBy": "admin",
+                "jcr:content": {
+                    "jcr:primaryType": "nt:resource",
+                    "jcr:mimeType": "text/html",
+                    ":jcr:data": 2402,
+                    "jcr:uuid": "0ae6d2c7-6fb1-43f2-8a84-3050458d6dca"
+                }
+            },
+            "cq:dialog": {
+                "jcr:primaryType": "nt:unstructured",
+                "jcr:title": "YouTube Options",
+                "sling:resourceType": "granite/ui/components/coral/foundation/container",
+                "items": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "youtubeVideoId": {
+                        "jcr:primaryType": "nt:unstructured",
+                        "sling:resourceType": "granite/ui/components/coral/foundation/form/textfield",
+                        "fieldDescription": "YouTube video ID.",
+                        "fieldLabel": "Video ID",
+                        "name": "./youtubeVideoId",
+                        "required": true
+                    },
+                    "youtubeWidth": {
+                        "jcr:primaryType": "nt:unstructured",
+                        "sling:resourceType": "granite/ui/components/coral/foundation/form/numberfield",
+                        "fieldDescription": "YouTube video player Width.",
+                        "fieldLabel": "Width",
+                        "name": "./youtubeWidth"
+                    },
+                    "youtubeHeight": {
+                        "jcr:primaryType": "nt:unstructured",
+                        "sling:resourceType": "granite/ui/components/coral/foundation/form/numberfield",
+                        "fieldDescription": "YouTube video player height.",
+                        "fieldLabel": "Height",
+                        "name": "./youtubeHeight"
+                    }
+                },
+                "granite:data": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "cmp-embed-dialog-edit-embeddableoptions": true,
+                    "cmp-embed-dialog-edit-showhidetargetvalue": "core-components-examples/components/embeddables/youtube"
+                }
+            },
+            "cq:design_dialog": {
+                "jcr:primaryType": "nt:unstructured",
+                "jcr:title": "YouTube Design Tab",
+                "sling:resourceType": "granite/ui/components/coral/foundation/container",
+                "items": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "youtubeVideoId": {
+                        "jcr:primaryType": "nt:unstructured",
+                        "sling:resourceType": "granite/ui/components/coral/foundation/form/textfield",
+                        "fieldDescription": "YouTube video ID.",
+                        "fieldLabel": "Video ID",
+                        "name": "./youtubeVideoId",
+                        "required": true
+                    },
+                    "youtubeWidth": {
+                        "jcr:primaryType": "nt:unstructured",
+                        "sling:resourceType": "granite/ui/components/coral/foundation/form/numberfield",
+                        "fieldDescription": "YouTube video player Width.",
+                        "fieldLabel": "Width",
+                        "name": "./youtubeWidth"
+                    },
+                    "youtubeHeight": {
+                        "jcr:primaryType": "nt:unstructured",
+                        "sling:resourceType": "granite/ui/components/coral/foundation/form/numberfield",
+                        "fieldDescription": "YouTube video player height.",
+                        "fieldLabel": "Height",
+                        "name": "./youtubeHeight"
+                    }
+                },
+                "granite:data": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "cmp-embed-dialog-edit-embeddableoptions": true,
+                    "cmp-embed-dialog-edit-showhidetargetvalue": "core-components-examples/components/embeddables/youtube"
+                }
+            }
+        },
+        "chatbot": {
+            "jcr:primaryType": "cq:Component",
+            "jcr:title": "Chatbot",
+            "sling:resourceSuperType": "core/wcm/components/embed/v1/embed/embeddable",
+            "order": 2,
+            "componentGroup": ".hidden",
+            "chatbot.html": {
+                "jcr:primaryType": "nt:file",
+                "jcr:content": {
+                    "jcr:primaryType": "nt:resource",
+                    "jcr:mimeType": "text/html",
+                    ":jcr:data": 2402,
+                    "jcr:uuid": "0ae6d2c7-6fb1-43f2-8a84-3050458d6dca"
+                }
+            },
+            "cq:dialog": {
+                "jcr:primaryType": "nt:unstructured",
+                "jcr:title": "Chatbot Options",
+                "sling:resourceType": "granite/ui/components/coral/foundation/container",
+                "items": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "chatbotId": {
+                        "jcr:primaryType": "nt:unstructured",
+                        "sling:resourceType": "granite/ui/components/coral/foundation/form/textfield",
+                        "fieldDescription": "Chatbot ID",
+                        "fieldLabel": "ID",
+                        "name": "./chatbotId",
+                        "required": true
+                    },
+                    "chatbotCaption": {
+                        "jcr:primaryType": "nt:unstructured",
+                        "sling:resourceType": "granite/ui/components/coral/foundation/form/textfield",
+                        "fieldDescription": "Chatbot caption.",
+                        "fieldLabel": "Caption",
+                        "name": "./chatbotCaption"
+                    }
+                },
+                "granite:data": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "cmp-embed-dialog-edit-embeddableoptions": true,
+                    "cmp-embed-dialog-edit-showhidetargetvalue": "core-components-examples/components/embeddables/chatbot"
+                }
+            }
+        },
+        "social": {
+            "jcr:primaryType": "cq:Component",
+            "jcr:title": "Social",
+            "sling:resourceSuperType": "core/wcm/components/embed/v1/embed/embeddable",
+            "order": 2,
+            "componentGroup": ".hidden",
+            "social.html": {
+                "jcr:primaryType": "nt:file",
+                "jcr:content": {
+                    "jcr:primaryType": "nt:resource",
+                    "jcr:mimeType": "text/html",
+                    ":jcr:data": 2402,
+                    "jcr:uuid": "0ae6d2c7-6fb1-43f2-8a84-3050458d6dca"
+                }
+            },
+            "cq:dialog": {
+                "jcr:primaryType": "nt:unstructured",
+                "jcr:title": "Social Options",
+                "sling:resourceType": "granite/ui/components/coral/foundation/container",
+                "items": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "socialId": {
+                        "jcr:primaryType": "nt:unstructured",
+                        "sling:resourceType": "granite/ui/components/coral/foundation/form/textfield",
+                        "fieldDescription": "Social ID.",
+                        "fieldLabel": "ID",
+                        "name": "./socialId",
+                        "required": true
+                    },
+                    "socialCaption": {
+                        "jcr:primaryType": "nt:unstructured",
+                        "sling:resourceType": "granite/ui/components/coral/foundation/form/textfield",
+                        "fieldDescription": "Social caption.",
+                        "fieldLabel": "Caption",
+                        "name": "./socialCaption"
+                    }
+                },
+                "granite:data": {
+                    "jcr:primaryType": "nt:unstructured",
+                    "cmp-embed-dialog-edit-embeddableoptions": true,
+                    "cmp-embed-dialog-edit-showhidetargetvalue": "core-components-examples/components/embeddables/social"
+                }
+            }
+        }
+    }
+}

--- a/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/README.md
@@ -35,6 +35,9 @@ The following configuration properties are used:
 1. `./htmlDisabled` - defines whether or not free-form HTML input is disabled in the edit dialog.
 3. `./allowedEmbeddables` - defines the embeddables that are allowed to be selected by an author when embeddables are not disabled.
 
+In addition once the YouTube embeddable is allowed a tab from [YouTube component](embeddable/youtube)'s design dialog is included.
+
+
 ### Edit Dialog Properties
 The following JCR properties are used:
 
@@ -62,6 +65,7 @@ By implementing the [UrlProcessor](../../../../../../../../../../../bundles/core
 You will also need to create an HTL template file, with the same name as the `processor` field returned in the `Result`.
 
 Example:
+
 * [Pinterest processor](../../../../../../../../../../../bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/services/embed/PinterestUrlProcessor.java)
 * [Pinterest HTL template](processors/pinterest.html)
 
@@ -70,9 +74,11 @@ Example:
 By adding an OSGi configuration you can embed an URL from an oEmbed provider.
 
 Example:
+
 * [YouTube configuration](../../../../../../../../../../../config/src/content/jcr_root/apps/core/wcm/config/com.adobe.cq.wcm.core.components.internal.services.embed.OEmbedClientImplConfigurationFactory-youtube.config)
 
 See also:
+
 * [oEmbed specification](https://oembed.com)
 * [oEmbed providers](https://oembed.com/providers.json)
 
@@ -82,20 +88,16 @@ See also:
 2. Create a rendering HTL script suitable for what your want to render.
 3. Create a cq:dialog node with only the configuration options needed for your embeddable.
 4. Make sure to have the following properties added to a `granite:data` node under the `cq:dialog` node:
-
-```
-cmp-embed-dialog-edit-embeddableoptions="true"
-cmp-embed-dialog-edit-showhidetargetvalue="<embeddableResourceType>"
-```
-where `<embeddableResourceType>` is the resource type of your custom embeddable. See [YouTube embeddable options](./embeddable/youtube/_cq_dialog/.content.xml#L42) for an example!
-
-
-5. The JCR properties for the edit configuration options of an embeddable _must_ be namespaced to prevent clashes. The following JCR properties are used for the provided YouTube embeddable:
-* `./youtubeVideoId` - defines the YouTube video ID.
-* `./youtubeWidth` - defines the YouTube video player width.
-* `./youtubeHeight` - defines the YouTube video player height.
+   
+   ```
+   cmp-embed-dialog-edit-embeddableoptions="true"
+   cmp-embed-dialog-edit-showhidetargetvalue="<embeddableResourceType>"
+   ```
+   where `<embeddableResourceType>` is the resource type of your custom embeddable. See [YouTube embeddable options](./embeddable/youtube/_cq_dialog/.content.xml#L42) for an example!
+5. The JCR properties for the edit configuration options of an embeddable _must_ be namespaced to prevent clashes. 
 
 Example:
+
 * [YouTube embeddable](embeddable/youtube)
 
 ### Security Recommendations

--- a/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/_cq_design_dialog/.content.xml
@@ -18,18 +18,23 @@
     jcr:primaryType="nt:unstructured"
     jcr:title="Embed"
     sling:resourceType="cq/gui/components/authoring/dialog"
+    extraClientlibs="[core.wcm.components.embed.v1.editor]"
     helpPath="https://www.adobe.com/go/aem_cmp_embed_v1">
     <content
         jcr:primaryType="nt:unstructured"
-        sling:resourceType="granite/ui/components/coral/foundation/container">
+        sling:resourceType="granite/ui/components/coral/foundation/container"
+        granite:class="cmp-embed__design-editor">
         <items jcr:primaryType="nt:unstructured">
             <tabs
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="granite/ui/components/coral/foundation/tabs">
-                <items jcr:primaryType="nt:unstructured">
+                <datasource
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="core/wcm/components/embed/v1/datasources/embeddesigntabs"/>
+                <firsttabs jcr:primaryType="nt:unstructured">
                     <properties
                         jcr:primaryType="nt:unstructured"
-                        jcr:title="Properties"
+                        jcr:title="Embeddable Types"
                         sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns">
                         <items jcr:primaryType="nt:unstructured">
                             <column
@@ -64,6 +69,7 @@
                                         uncheckedValue="false"
                                         value="{Boolean}true"/>
                                     <allowedEmbeddables
+                                        granite:class="allowed-embeddables"
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/form/select"
                                         deleteHint="{Boolean}true"
@@ -74,16 +80,21 @@
                                         <datasource
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="core/wcm/components/embed/v1/datasources/embeddables"/>
+                                        <granite:data
+                                            jcr:primaryType="nt:unstructured"
+                                            cmp-embed-dialog-edit-showhidetarget="\[data-cmp-embed-dialog-edit-youtube\]"/>
                                     </allowedEmbeddables>
                                 </items>
                             </column>
                         </items>
                     </properties>
+                 </firsttabs>
+                 <lasttabs jcr:primaryType="nt:unstructured">
                     <styletab
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="granite/ui/components/coral/foundation/include"
                         path="/mnt/overlay/cq/gui/components/authoring/dialog/style/tab_design/styletab"/>
-                </items>
+                </lasttabs>
             </tabs>
         </items>
     </content>

--- a/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/clientlibs/editor/js/embed.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/clientlibs/editor/js/embed.js
@@ -21,6 +21,9 @@
 
     var selectors = {
         dialogContent: ".cmp-embed__editor",
+        designDialogContent: ".cmp-embed__design-editor",
+        allowedEmbeddables: ".allowed-embeddables",
+        toggleCheckboxes: ".toggle-checkbox",
         embeddableField: "[data-cmp-embed-dialog-edit-hook='embeddableField']",
         typeField: "[data-cmp-embed-dialog-edit-hook='typeField']",
         typeRadio: "[data-cmp-embed-dialog-edit-hook='typeField'] coral-radio",
@@ -187,8 +190,85 @@
                     }
                 }
             }
+
+            var designDialogContent = $dialog[0].querySelector(selectors.designDialogContent);
+            if (designDialogContent) {
+                // for all toggles
+                var toggleCheckboxes = designDialogContent.querySelectorAll(selectors.toggleCheckboxes);
+                toggleCheckboxes.forEach(function(toggleCheckbox) {
+                    Coral.commons.ready(toggleCheckbox, function() {
+                        var showHideTarget = getShowHideTarget(toggleCheckbox);
+
+                        // either hide or show them depending on the value of the toggle
+                        toggleShowHideTargets(showHideTarget, toggleCheckbox.checked.toString());
+
+                        // register an event handler
+                        toggleCheckbox.on("change", function() {
+                            toggleShowHideTargets(showHideTarget, toggleCheckbox.checked.toString());
+                        });
+                    });
+                });
+            }
         }
     });
+
+    /**
+     * This is triggered after "dialog-loaded" but is required, as otherwise the relation between panel and tab is not yet established.
+     */
+    $(document).on("dialog-ready", function() {
+        var designDialogContent = document.querySelector(selectors.designDialogContent);
+        if (designDialogContent) {
+            // for all optional tabs
+            var allowedEmbeddablesDropdown = designDialogContent.querySelector(selectors.allowedEmbeddables);
+            Coral.commons.ready(allowedEmbeddablesDropdown, function() {
+                var panelSelectors = getShowHideTarget(allowedEmbeddablesDropdown);
+                // register an event handler
+                allowedEmbeddablesDropdown.on("change", function() {
+                    toggleShowHideTabs(panelSelectors, allowedEmbeddablesDropdown.value);
+                });
+                // set initial state inside requestAnimationFrame as only there the relevant attribute "aria-labelledby" is set
+                window.requestAnimationFrame((function() {
+                    toggleShowHideTabs(panelSelectors, allowedEmbeddablesDropdown.value);
+                }));
+            });
+        }
+    });
+
+    /**
+     * Toggles the disabled state and visibility of tabs linked to panels matching the target.
+     * Tabs that match the provided value are enabled / shown, otherwise they are disabled / hidden.
+     *
+     * @param {String} panelSelectors Comma separated list of panel selectors for which the tabs should be toggled
+     * @param {String} value The value of the target to enable and show
+     */
+    function toggleShowHideTabs(panelSelectors, value) {
+        var panelElements = document.querySelectorAll(panelSelectors);
+
+        for (var i = 0; i < panelElements.length; i++) {
+            var panelElement = panelElements[i];
+            var showHideTargetValue = getShowHideTargetValue(panelElement);
+            var tabElement = getTabElementForPanel(panelElement);
+            if (showHideTargetValue === value) {
+                toggleTarget($(tabElement), true);
+            } else {
+                toggleTarget($(tabElement), false);
+            }
+        }
+    }
+
+    /**
+     * Retrieves the tab element connected to a given panel element
+     *
+     * @param {Element} panelElement The panel element for which to return the tab element
+     * @returns {Element} The related tab element
+     */
+    function getTabElementForPanel(panelElement) {
+        // go to one level below panelstack
+        var panel = panelElement.parentElement.parentElement;
+        // get tab id controlling this panel
+        var tabId = panel.getAttribute("aria-labelledby");
+        return document.getElementById(tabId);
+    }
 
     /**
      * Toggles the disabled state and visibility of elements matching the target.

--- a/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/embeddable/youtube/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/embeddable/youtube/README.md
@@ -1,0 +1,64 @@
+<!--
+Copyright 2021 Adobe
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+YouTube Embeddable (v1)
+====
+YouTube component written in HTL that includes the YouTube player via an iFrame. It is used from the [Embed component](../..).
+
+## Features
+* Allows to configure player parameters
+* Each player parameter can be enabled and given a default value by a template author.
+
+### Component Policy Configuration Properties
+The following configuration properties are used and exposed on the embed component's design dialog:
+
+1. `./youtubeMuteEnabled` - enables the ability of content authors to configure the [YouTube mute parameter][yt-parameters].
+1. `./youtubeMuteDefaultValue` - the default value of the [YouTube mute parameter][yt-parameters].
+1. `./youtubeAutoPlayEnabled` - enables the ability of content authors to configure the [YouTube Autoplay parameter][yt-parameters]. 
+1. `./youtubeAutoPlayDefaultValue` - the default value of the [YouTube Autoplay parameter][yt-parameters]. Be aware that modern browsers restrict the possibilities for autoplay. Further information: [Chrome Autoplay Policy](https://developers.google.com/web/updates/2017/09/autoplay-policy-changes), [Firefox Autoplay Policy](https://support.mozilla.org/en-US/kb/block-autoplay), [MS Edge Autoplay Policy](https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/browser-features/autoplay-policies). In general it is much more likely that autoplay works if combined with `mute`.
+1. `./youtubeLoopEnabled` - enables the ability of content authors to configure the [YouTube loop parameter][yt-parameters].
+1. `./youtubeLoopDefaultValue` - the default value of the [YouTube loop parameter][yt-parameters].
+1. `./youtubePlaysInlineEnabled` - enables the ability of content authors to configure the [YouTube playsinline parameter][yt-parameters].
+1. `./youtubePlaysInlineDefaultValue` - the default value of the [YouTube playsinline parameter][yt-parameters].
+1. `./youtubeRelatedVideosEnabled` - enables the ability of content authors to configure the [YouTube rel parameter][yt-parameters].
+1. `./youtubeRelatedVideosDefaultValue` - the default value of the [YouTube rel parameter][yt-parameters].
+
+
+### Edit Dialog Properties
+The following JCR properties are used:
+
+1. `./youtubeVideoId` - defines the YouTube video ID.
+1. `./youtubeWidth` - defines the YouTube video player width.
+1. `./youtubeHeight` - defines the YouTube video player height.
+1. `./youtubeMute` - the value of the [YouTube mute parameter][yt-parameters].
+1. `./youtubeAutoPlay` - the value of the [YouTube autoplay parameter][yt-parameters]. Be aware that modern browsers restrict the possibilities for autoplay. Further information: [Chrome Autoplay Policy](https://developers.google.com/web/updates/2017/09/autoplay-policy-changes), [Firefox Autoplay Policy](https://support.mozilla.org/en-US/kb/block-autoplay), [MS Edge Autoplay Policy](https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/browser-features/autoplay-policies). In general it is much more likely that autoplay works if combined with `mute`.
+1. `./youtubeLoop` - the value of the [YouTube loop parameter][yt-parameters].
+1. `./youtubePlaysInline` - the value of the [YouTube playsinline parameter][yt-parameters].
+1. `./youtubeRel` - the default value of the [YouTube rel parameter][yt-parameters].
+
+
+## Information
+* **Vendor**: Adobe
+* **Version**: v1
+* **Compatibility**: AEM 6.3
+* **Status**: production-ready
+* **Documentation**: [https://www.adobe.com/go/aem\_cmp\_embed\_v1](https://www.adobe.com/go/aem_cmp_embed_v1)
+* **Component Library**: [https://www.adobe.com/go/aem\_cmp\_library\_embed](https://www.adobe.com/go/aem_cmp_library_embed)
+* **Author**: [Konrad Windszus](https://github.com/kwin)
+* **Co-authors**: [Jean-Christophe Kautzmann](https://github.com/jckautzmann), [Richard Hand](https://github.com/richardhand), [Vlad Bailescu](https://github.com/vladbailescu)
+
+_If you were involved in the authoring of this component and are not credited above, please reach out to us on [GitHub](https://github.com/adobe/aem-core-wcm-components)._
+
+[yt-parameters]: https://developers.google.com/youtube/player_parameters

--- a/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/embeddable/youtube/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/embeddable/youtube/_cq_design_dialog/.content.xml
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright 2021 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="YouTube"
+    sling:resourceType="granite/ui/components/coral/foundation/container">
+    <granite:data
+        jcr:primaryType="nt:unstructured"
+        cmp-embed-dialog-edit-youtube="true"
+        cmp-embed-dialog-edit-showhidetargetvalue="core/wcm/components/embed/v1/embed/embeddable/youtube"/>
+    <items jcr:primaryType="nt:unstructured">
+        <mute
+            granite:class="toggle-checkbox"
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+            checked="false"
+            fieldDescription="When checked, enables the ability of content authors to configure this parameter. Otherwise the YouTube default is taken."
+            name="./youtubeMuteEnabled"
+            text="Allow configuration of Mute behaviour"
+            uncheckedValue="false"
+            value="true">
+            <granite:data
+                jcr:primaryType="nt:unstructured"
+                cmp-embed-dialog-edit-showhidetarget="\[data-cmp-embed-dialog-edit-mute\]"/>
+        </mute>
+        <muteGroup
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/coral/foundation/well">
+            <items jcr:primaryType="nt:unstructured">
+                <enable
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                    checked="false"
+                    fieldDescription="This parameter specifies whether the video will play muted by default. Enabling this increases the chance that Autoplay works in modern browsers."
+                    name="./youtubeMuteDefaultValue"
+                    text="Default Value of Mute"
+                    uncheckedValue="false"
+                    value="true"/>
+            </items>
+            <granite:data
+                jcr:primaryType="nt:unstructured"
+                cmp-embed-dialog-edit-mute="true"
+                cmp-embed-dialog-edit-showhidetargetvalue="true"/>
+        </muteGroup>
+        <autoplay
+            granite:class="toggle-checkbox"
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+            checked="false"
+            fieldDescription="When checked, enables the ability of content authors to configure this parameter. Otherwise the YouTube default is taken."
+            name="./youtubeAutoPlayEnabled"
+            text="Allow configuration of Autoplay behaviour"
+            uncheckedValue="false"
+            value="true">
+            <granite:data
+                jcr:primaryType="nt:unstructured"
+                cmp-embed-dialog-edit-showhidetarget="\[data-cmp-embed-dialog-edit-autoplay\]"/>
+        </autoplay>
+        <autoplayGroup
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/coral/foundation/well">
+            <items jcr:primaryType="nt:unstructured">
+                <enable
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                    checked="false"
+                    fieldDescription="This parameter specifies whether the initial video will automatically start to play when the player loads."
+                    name="./youtubeAutoPlayDefaultValue"
+                    text="Default Value of Autoplay"
+                    uncheckedValue="false"
+                    value="true"/>
+            </items>
+            <granite:data
+                jcr:primaryType="nt:unstructured"
+                cmp-embed-dialog-edit-autoplay="true"
+                cmp-embed-dialog-edit-showhidetargetvalue="true"/>
+        </autoplayGroup>
+        <loop
+            granite:class="toggle-checkbox"
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+            checked="false"
+            fieldDescription="When checked, enables the ability of content authors to configure this parameter. Otherwise the YouTube default is taken."
+            name="./youtubeLoopEnabled"
+            text="Allow configuration of Loop behaviour"
+            uncheckedValue="false"
+            value="true">
+            <granite:data
+                jcr:primaryType="nt:unstructured"
+                cmp-embed-dialog-edit-showhidetarget="\[data-cmp-embed-dialog-edit-loop\]"/>
+        </loop>
+        <loopGroup
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/coral/foundation/well">
+            <items jcr:primaryType="nt:unstructured">
+                <enable
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                    checked="false"
+                    fieldDescription="In the case of a single video specifies whether the player should play the initial video again and again. In the case of a playlist, the player plays the entire playlist and then starts again at the first video."
+                    name="./youtubeLoopDefaultValue"
+                    text="Default Value of Loop"
+                    uncheckedValue="false"
+                    value="true"/>
+            </items>
+            <granite:data
+                jcr:primaryType="nt:unstructured"
+                cmp-embed-dialog-edit-loop="true"
+                cmp-embed-dialog-edit-showhidetargetvalue="true"/>
+        </loopGroup>
+        <inline
+            granite:class="toggle-checkbox"
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+            checked="false"
+            fieldDescription="When checked, enables the ability of content authors to configure this parameter. Otherwise the YouTube default is taken."
+            name="./youtubePlaysInlineEnabled"
+            text="Allow configuration of Inline Playback (iOS)"
+            uncheckedValue="false"
+            value="true">
+            <granite:data
+                jcr:primaryType="nt:unstructured"
+                cmp-embed-dialog-edit-showhidetarget="\[data-cmp-embed-dialog-edit-inline\]"/>
+        </inline>
+        <inlineGroup
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/coral/foundation/well">
+            <items jcr:primaryType="nt:unstructured">
+                <enable
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                    checked="false"
+                    fieldDescription="This parameter controls whether videos play inline (on) or fullscreen (off) in an HTML5 player on iOS."
+                    name="./youtubePlaysInlineDefaultValue"
+                    text="Default Value of Inline Playback (iOS)"
+                    uncheckedValue="false"
+                    value="true"/>
+            </items>
+            <granite:data
+                jcr:primaryType="nt:unstructured"
+                cmp-embed-dialog-edit-inline="true"
+                cmp-embed-dialog-edit-showhidetargetvalue="true"/>
+        </inlineGroup>
+        <rel
+            granite:class="toggle-checkbox"
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+            checked="false"
+            fieldDescription="When checked, enables the ability of content authors to configure this parameter. Otherwise the YouTube default is taken."
+            name="./youtubeRelatedVideosEnabled"
+            text="Allow configuration of related videos"
+            uncheckedValue="false"
+            value="true">
+            <granite:data
+                jcr:primaryType="nt:unstructured"
+                cmp-embed-dialog-edit-showhidetarget="\[data-cmp-embed-dialog-edit-rel\]"/>
+        </rel>
+        <relGroup
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/coral/foundation/well">
+            <items jcr:primaryType="nt:unstructured">
+                <enable
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                    checked="true"
+                    fieldDescription="If disabled related videos will come from the same channel as the video that was just played, otherwise from any channel."
+                    name="./youtubeRelatedVideosDefaultValue"
+                    text="Default Value of Unrestricted Related Videos"
+                    uncheckedValue="false"
+                    value="true"/>
+            </items>
+            <granite:data
+                jcr:primaryType="nt:unstructured"
+                cmp-embed-dialog-edit-rel="true"
+                cmp-embed-dialog-edit-showhidetargetvalue="true"/>
+        </relGroup>
+    </items>
+</jcr:root>

--- a/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/embeddable/youtube/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/embeddable/youtube/_cq_dialog/.content.xml
@@ -38,6 +38,84 @@
             fieldDescription="Height of the YouTube video player."
             fieldLabel="Height"
             name="./youtubeHeight"/>
+        <parameters
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/coral/foundation/container"
+            fieldDescription="Parameters of the YouTube video player."
+            fieldLabel="Parameters">
+            <items jcr:primaryType="nt:unstructured">
+                <mute
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                    text="Enable Mute"
+                    checked="${cqDesign.youtubeMuteDefaultValue == 'true'}"
+                    uncheckedValue="false"
+                    value="true"
+                    fieldDescription="This parameter specifies whether the video will play muted by default. Enabling this increases the chance that Autoplay works in modern browsers."
+                    name="./youtubeMute">
+                    <granite:rendercondition
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/foundation/renderconditions/simple"
+                        expression="${cqDesign.youtubeMuteEnabled == 'true'}"/>
+                </mute>
+                <autoplay
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                    text="Enable Autoplay"
+                    checked="${cqDesign.youtubeAutoPlayDefaultValue == 'true'}"
+                    uncheckedValue="false"
+                    value="true"
+                    fieldDescription="This parameter specifies whether the initial video will automatically start to play when the player loads. This is only effective on Publish or when using &quot;View as Published&quot;."
+                    name="./youtubeAutoPlay">
+                    <granite:rendercondition
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/foundation/renderconditions/simple"
+                        expression="${cqDesign.youtubeAutoPlayEnabled == 'true'}"/>
+                </autoplay>
+                <loop
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                    text="Enable Loop"
+                    checked="${cqDesign.youtubeLoopDefaultValue == 'true'}"
+                    uncheckedValue="false"
+                    value="true"
+                    fieldDescription="In the case of a single video specifies whether the player should play the initial video again and again. In the case of a playlist, the player plays the entire playlist and then starts again at the first video."
+                    name="./youtubeLoop">
+                    <granite:rendercondition
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/foundation/renderconditions/simple"
+                        expression="${cqDesign.youtubeLoopEnabled == 'true'}"/>
+                </loop>
+                <inline
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                    text="Enable Inline Playback (iOS)"
+                    checked="${cqDesign.youtubePlaysInlineDefaultValue == 'true'}"
+                    uncheckedValue="false"
+                    value="true"
+                    fieldDescription="This parameter controls whether videos play inline (on) or fullscreen (off) in an HTML5 player on iOS."
+                    name="./youtubePlaysInline">
+                    <granite:rendercondition
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/foundation/renderconditions/simple"
+                        expression="${cqDesign.youtubePlaysInlineEnabled == 'true'}"/>
+                </inline>
+                <rel
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                    text="Unrestricted Related Videos"
+                    checked="${cqDesign.youtubeRelatedVideosDefaultValue != 'false'}"
+                    uncheckedValue="false"
+                    value="true"
+                    fieldDescription="If disabled related videos will come from the same channel as the video that was just played, otherwise from any channel."
+                    name="./youtubeRel">
+                    <granite:rendercondition
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/foundation/renderconditions/simple"
+                        expression="${cqDesign.youtubeRelatedVideosEnabled == 'true'}"/>
+                </rel>
+            </items>/
+        </parameters>
     </items>
     <granite:data
         jcr:primaryType="nt:unstructured"

--- a/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/embeddable/youtube/youtube.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/embed/v1/embed/embeddable/youtube/youtube.html
@@ -13,10 +13,12 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<iframe data-sly-test="${properties.youtubeVideoId}"
-        width="${properties.youtubeWidth || '100%' @ context='scriptString'}"
-        height="${properties.youtubeHeight || 390 @ context='scriptString'}"
-        src="${'https://www.youtube.com/embed/{0}?origin={1}://{2}' @ format=[properties.youtubeVideoId, request.scheme, request.serverName]}"
+<iframe data-sly-use.youTube="com.adobe.cq.wcm.core.components.models.embeddable.YouTube"
+        data-sly-test="${!youtube.empty}"
+        width="${youTube.iFrameWidth || '100%' @ context='scriptString'}"
+        height="${youTube.iFrameHeight || 390 @ context='scriptString'}"
+        src="${youTube.iFrameSrc}"
         frameborder="0"
         allowfullscreen
+        allow="autoplay; fullscreen"
         aria-label="${'YouTube Video' @ i18n}"></iframe>


### PR DESCRIPTION
* Enable configuration of YouTube Player parameters

All parameters are opt-in, i.e. need to be enabled via content policies.
Their default values can be given via content policies as well.
The parameters are documented in
https://developers.google.com/youtube/player_parameters#Parameters

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
